### PR TITLE
Set passive panel to the same dir as active panel

### DIFF
--- a/k-Shell/k-Alt=/v-DisableOutput
+++ b/k-Shell/k-Alt=/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt=/v-Sequence
+++ b/k-Shell/k-Alt=/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+Tab Ctrl\\ CtrlPgUp - Tab\0


### PR DESCRIPTION
Add shortcut `Alt+=` to set the passive panel to the same directory as the active one.

Note: Parameter "Options->Interface->Use Ctrl-PgUp to change drive" should be ON!

Sequence description:

1. `Tab`    - to switch to passive panel
2. `Ctrl+\`  - to go to the root directory
3. `Ctrl+PgUp` - to get drive selection dialog
4. `-`  - to select the same directory
5. `Tab` - to switch back to previously active panel