### PR TITLE
Add Alt+0..9 macros for switching between screens

### DIFF
--- a/k-Editor/k-Alt0/v-DisableOutput
+++ b/k-Editor/k-Alt0/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt0/v-FilePanels
+++ b/k-Editor/k-Alt0/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt0/v-PluginPanels
+++ b/k-Editor/k-Alt0/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt0/v-Sequence
+++ b/k-Editor/k-Alt0/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 0\0

--- a/k-Editor/k-Alt1/v-DisableOutput
+++ b/k-Editor/k-Alt1/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt1/v-FilePanels
+++ b/k-Editor/k-Alt1/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt1/v-PluginPanels
+++ b/k-Editor/k-Alt1/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt1/v-Sequence
+++ b/k-Editor/k-Alt1/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 1\0

--- a/k-Editor/k-Alt2/v-DisableOutput
+++ b/k-Editor/k-Alt2/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt2/v-FilePanels
+++ b/k-Editor/k-Alt2/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt2/v-PluginPanels
+++ b/k-Editor/k-Alt2/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt2/v-Sequence
+++ b/k-Editor/k-Alt2/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 2\0

--- a/k-Editor/k-Alt3/v-DisableOutput
+++ b/k-Editor/k-Alt3/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt3/v-FilePanels
+++ b/k-Editor/k-Alt3/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt3/v-PluginPanels
+++ b/k-Editor/k-Alt3/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt3/v-Sequence
+++ b/k-Editor/k-Alt3/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 3\0

--- a/k-Editor/k-Alt4/v-DisableOutput
+++ b/k-Editor/k-Alt4/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt4/v-FilePanels
+++ b/k-Editor/k-Alt4/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt4/v-PluginPanels
+++ b/k-Editor/k-Alt4/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt4/v-Sequence
+++ b/k-Editor/k-Alt4/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 4\0

--- a/k-Editor/k-Alt5/v-DisableOutput
+++ b/k-Editor/k-Alt5/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt5/v-FilePanels
+++ b/k-Editor/k-Alt5/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt5/v-PluginPanels
+++ b/k-Editor/k-Alt5/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt5/v-Sequence
+++ b/k-Editor/k-Alt5/v-Sequence
@@ -1,0 +1,4 @@
+
+Sequence
+SZ
+F12 5\0

--- a/k-Editor/k-Alt6/v-DisableOutput
+++ b/k-Editor/k-Alt6/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt6/v-FilePanels
+++ b/k-Editor/k-Alt6/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt6/v-PluginPanels
+++ b/k-Editor/k-Alt6/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt6/v-Sequence
+++ b/k-Editor/k-Alt6/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 6\0

--- a/k-Editor/k-Alt7/v-DisableOutput
+++ b/k-Editor/k-Alt7/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt7/v-FilePanels
+++ b/k-Editor/k-Alt7/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt7/v-PluginPanels
+++ b/k-Editor/k-Alt7/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt7/v-Sequence
+++ b/k-Editor/k-Alt7/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 7\0

--- a/k-Editor/k-Alt8/v-DisableOutput
+++ b/k-Editor/k-Alt8/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt8/v-FilePanels
+++ b/k-Editor/k-Alt8/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt8/v-PluginPanels
+++ b/k-Editor/k-Alt8/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt8/v-Sequence
+++ b/k-Editor/k-Alt8/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 8\0

--- a/k-Editor/k-Alt9/v-DisableOutput
+++ b/k-Editor/k-Alt9/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Editor/k-Alt9/v-FilePanels
+++ b/k-Editor/k-Alt9/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Editor/k-Alt9/v-PluginPanels
+++ b/k-Editor/k-Alt9/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Editor/k-Alt9/v-Sequence
+++ b/k-Editor/k-Alt9/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 9\0

--- a/k-Shell/k-Alt0/v-DisableOutput
+++ b/k-Shell/k-Alt0/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt0/v-FilePanels
+++ b/k-Shell/k-Alt0/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt0/v-PluginPanels
+++ b/k-Shell/k-Alt0/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt0/v-Sequence
+++ b/k-Shell/k-Alt0/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 0\0

--- a/k-Shell/k-Alt1/v-DisableOutput
+++ b/k-Shell/k-Alt1/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt1/v-FilePanels
+++ b/k-Shell/k-Alt1/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt1/v-PluginPanels
+++ b/k-Shell/k-Alt1/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt1/v-Sequence
+++ b/k-Shell/k-Alt1/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 1\0

--- a/k-Shell/k-Alt2/v-DisableOutput
+++ b/k-Shell/k-Alt2/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt2/v-FilePanels
+++ b/k-Shell/k-Alt2/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt2/v-PluginPanels
+++ b/k-Shell/k-Alt2/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt2/v-Sequence
+++ b/k-Shell/k-Alt2/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 2\0

--- a/k-Shell/k-Alt3/v-DisableOutput
+++ b/k-Shell/k-Alt3/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt3/v-FilePanels
+++ b/k-Shell/k-Alt3/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt3/v-PluginPanels
+++ b/k-Shell/k-Alt3/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt3/v-Sequence
+++ b/k-Shell/k-Alt3/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 3\0

--- a/k-Shell/k-Alt4/v-DisableOutput
+++ b/k-Shell/k-Alt4/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt4/v-FilePanels
+++ b/k-Shell/k-Alt4/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt4/v-PluginPanels
+++ b/k-Shell/k-Alt4/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt4/v-Sequence
+++ b/k-Shell/k-Alt4/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 4\0

--- a/k-Shell/k-Alt5/v-DisableOutput
+++ b/k-Shell/k-Alt5/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt5/v-FilePanels
+++ b/k-Shell/k-Alt5/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt5/v-PluginPanels
+++ b/k-Shell/k-Alt5/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt5/v-Sequence
+++ b/k-Shell/k-Alt5/v-Sequence
@@ -1,0 +1,4 @@
+
+Sequence
+SZ
+F12 5\0

--- a/k-Shell/k-Alt6/v-DisableOutput
+++ b/k-Shell/k-Alt6/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt6/v-FilePanels
+++ b/k-Shell/k-Alt6/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt6/v-PluginPanels
+++ b/k-Shell/k-Alt6/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt6/v-Sequence
+++ b/k-Shell/k-Alt6/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 6\0

--- a/k-Shell/k-Alt7/v-DisableOutput
+++ b/k-Shell/k-Alt7/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt7/v-FilePanels
+++ b/k-Shell/k-Alt7/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt7/v-PluginPanels
+++ b/k-Shell/k-Alt7/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt7/v-Sequence
+++ b/k-Shell/k-Alt7/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 7\0

--- a/k-Shell/k-Alt8/v-DisableOutput
+++ b/k-Shell/k-Alt8/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt8/v-FilePanels
+++ b/k-Shell/k-Alt8/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt8/v-PluginPanels
+++ b/k-Shell/k-Alt8/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt8/v-Sequence
+++ b/k-Shell/k-Alt8/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 8\0

--- a/k-Shell/k-Alt9/v-DisableOutput
+++ b/k-Shell/k-Alt9/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Shell/k-Alt9/v-FilePanels
+++ b/k-Shell/k-Alt9/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Shell/k-Alt9/v-PluginPanels
+++ b/k-Shell/k-Alt9/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Shell/k-Alt9/v-Sequence
+++ b/k-Shell/k-Alt9/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 9\0

--- a/k-Viewer/k-Alt0/v-DisableOutput
+++ b/k-Viewer/k-Alt0/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt0/v-FilePanels
+++ b/k-Viewer/k-Alt0/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt0/v-PluginPanels
+++ b/k-Viewer/k-Alt0/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt0/v-Sequence
+++ b/k-Viewer/k-Alt0/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 0\0

--- a/k-Viewer/k-Alt1/v-DisableOutput
+++ b/k-Viewer/k-Alt1/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt1/v-FilePanels
+++ b/k-Viewer/k-Alt1/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt1/v-PluginPanels
+++ b/k-Viewer/k-Alt1/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt1/v-Sequence
+++ b/k-Viewer/k-Alt1/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 1\0

--- a/k-Viewer/k-Alt2/v-DisableOutput
+++ b/k-Viewer/k-Alt2/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt2/v-FilePanels
+++ b/k-Viewer/k-Alt2/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt2/v-PluginPanels
+++ b/k-Viewer/k-Alt2/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt2/v-Sequence
+++ b/k-Viewer/k-Alt2/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 2\0

--- a/k-Viewer/k-Alt3/v-DisableOutput
+++ b/k-Viewer/k-Alt3/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt3/v-FilePanels
+++ b/k-Viewer/k-Alt3/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt3/v-PluginPanels
+++ b/k-Viewer/k-Alt3/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt3/v-Sequence
+++ b/k-Viewer/k-Alt3/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 3\0

--- a/k-Viewer/k-Alt4/v-DisableOutput
+++ b/k-Viewer/k-Alt4/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt4/v-FilePanels
+++ b/k-Viewer/k-Alt4/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt4/v-PluginPanels
+++ b/k-Viewer/k-Alt4/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt4/v-Sequence
+++ b/k-Viewer/k-Alt4/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 4\0

--- a/k-Viewer/k-Alt5/v-DisableOutput
+++ b/k-Viewer/k-Alt5/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt5/v-FilePanels
+++ b/k-Viewer/k-Alt5/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt5/v-PluginPanels
+++ b/k-Viewer/k-Alt5/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt5/v-Sequence
+++ b/k-Viewer/k-Alt5/v-Sequence
@@ -1,0 +1,4 @@
+
+Sequence
+SZ
+F12 5\0

--- a/k-Viewer/k-Alt6/v-DisableOutput
+++ b/k-Viewer/k-Alt6/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt6/v-FilePanels
+++ b/k-Viewer/k-Alt6/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt6/v-PluginPanels
+++ b/k-Viewer/k-Alt6/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt6/v-Sequence
+++ b/k-Viewer/k-Alt6/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 6\0

--- a/k-Viewer/k-Alt7/v-DisableOutput
+++ b/k-Viewer/k-Alt7/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt7/v-FilePanels
+++ b/k-Viewer/k-Alt7/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt7/v-PluginPanels
+++ b/k-Viewer/k-Alt7/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt7/v-Sequence
+++ b/k-Viewer/k-Alt7/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 7\0

--- a/k-Viewer/k-Alt8/v-DisableOutput
+++ b/k-Viewer/k-Alt8/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt8/v-FilePanels
+++ b/k-Viewer/k-Alt8/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt8/v-PluginPanels
+++ b/k-Viewer/k-Alt8/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt8/v-Sequence
+++ b/k-Viewer/k-Alt8/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 8\0

--- a/k-Viewer/k-Alt9/v-DisableOutput
+++ b/k-Viewer/k-Alt9/v-DisableOutput
@@ -1,0 +1,3 @@
+DisableOutput
+DWORD
+1

--- a/k-Viewer/k-Alt9/v-FilePanels
+++ b/k-Viewer/k-Alt9/v-FilePanels
@@ -1,0 +1,3 @@
+FilePanels
+DWORD
+1

--- a/k-Viewer/k-Alt9/v-PluginPanels
+++ b/k-Viewer/k-Alt9/v-PluginPanels
@@ -1,0 +1,3 @@
+PluginPanels
+DWORD
+1

--- a/k-Viewer/k-Alt9/v-Sequence
+++ b/k-Viewer/k-Alt9/v-Sequence
@@ -1,0 +1,3 @@
+Sequence
+SZ
+F12 9\0


### PR DESCRIPTION
This PR adds Alt+0..9 macros to switch between screens in FAR. I was using it a lot in FAR for Windows.
Ported from AltScreens.reg