### PR TITLE
Fixed all k-Alt5 because of https://github.com/elfmz/far2l/issues/897

### DIFF
--- a/k-Editor/k-Alt5/v-Sequence
+++ b/k-Editor/k-Alt5/v-Sequence
@@ -1,4 +1,3 @@
-
 Sequence
 SZ
 F12 5\0

--- a/k-Shell/k-Alt5/v-Sequence
+++ b/k-Shell/k-Alt5/v-Sequence
@@ -1,4 +1,3 @@
-
 Sequence
 SZ
 F12 5\0

--- a/k-Viewer/k-Alt5/v-Sequence
+++ b/k-Viewer/k-Alt5/v-Sequence
@@ -1,4 +1,3 @@
-
 Sequence
 SZ
 F12 5\0


### PR DESCRIPTION
Hello,
Thanks so much for porting my favorite macros!
There was found one unobvious issue: extra leading newline (0x0A) does not lead to complain while starting far2l, but provokes the corruption while saving settings.
I patched this issue by just removing this newline.

Regards.